### PR TITLE
Catch and log problems with TOML parsing

### DIFF
--- a/indexer.py
+++ b/indexer.py
@@ -160,7 +160,12 @@ def index_page(path, breadcrumb, uri, index):
     else:
         front_matter_start = matches[0].start(1)
         front_matter_end = matches[1].start(1)
-        data = toml.loads(source_text[(front_matter_start + 3):front_matter_end])
+        try:
+            data = toml.loads(source_text[(front_matter_start + 3):front_matter_end])
+        except:
+            logging.warn("Indexing page %s: Error parsing front matter. Please check syntax. Skipping page." % path)
+            # Don't do anything else with this page
+            return
         text = markdown_to_text(source_text_unicode[(front_matter_end+3):])
         for key in data.keys():
             if type(data[key]) == str:


### PR DESCRIPTION
This change should make the indexer stay alive and index most pages if there is a problem in the frontmatter of one page.

RFR @giantswarm/team-l8