### PR TITLE
Using latest instead of SHA image tag

### DIFF
--- a/helm/docs-indexer-chart/templates/cronjob.yaml
+++ b/helm/docs-indexer-chart/templates/cronjob.yaml
@@ -18,7 +18,7 @@ spec:
           containers:
           - name: indexer
             # This image is supposed to be publicly accessible
-            image: quay.io/giantswarm/docs-indexer:[[ .SHA ]]
+            image: quay.io/giantswarm/docs-indexer:latest
             env:
               - name: ELASTICSEARCH_ENDPOINT
                 valueFrom:


### PR DESCRIPTION
As the `[[ .SHA ]]` placeholder wasn't replaced