### PR TITLE
Add responses.yaml to YAML files list

### DIFF
--- a/helm/docs-indexer-chart/templates/cronjob.yaml
+++ b/helm/docs-indexer-chart/templates/cronjob.yaml
@@ -40,7 +40,7 @@ spec:
               - name: APIDOCS_BASE_PATH
                 value: /api/
               - name: API_SPEC_FILES
-                value: yaml/spec.yaml,yaml/definitions.yaml,yaml/parameters.yaml
+                value: yaml/spec.yaml,yaml/definitions.yaml,yaml/parameters.yaml,yaml/responses.yaml
           restartPolicy: OnFailure
           # retry for a maximum of 10 minutes
           activeDeadlineSeconds: 600


### PR DESCRIPTION
docs-indexer currently fails with this error:

```
2018-07-19 07:44:07,804 - root - INFO - Reading URL https://docs.giantswarm.io/api/yaml/spec.yaml
2018-07-19 07:44:08,008 - root - INFO - Reading URL https://docs.giantswarm.io/api/yaml/definitions.yaml
2018-07-19 07:44:08,168 - root - INFO - Reading URL https://docs.giantswarm.io/api/yaml/parameters.yaml
Traceback (most recent call last):
  File "indexer.py", line 320, in <module>
    index_openapi_spec(APIDOCS_BASE_URI, APIDOCS_BASE_PATH, API_SPEC_FILES, tempindex)
  File "indexer.py", line 223, in index_openapi_spec
    parser = ResolvingParser(tmpdir + os.path.sep + os.path.basename(files[0]))
  File "/usr/local/lib/python2.7/site-packages/prance/__init__.py", line 164, in __init__
    **kwargs
  File "/usr/local/lib/python2.7/site-packages/prance/__init__.py", line 94, in __init__
    self.parse()
  File "/usr/local/lib/python2.7/site-packages/prance/__init__.py", line 124, in parse
    self._validate()
  File "/usr/local/lib/python2.7/site-packages/prance/__init__.py", line 175, in _validate
    resolver.resolve_references()
  File "/usr/local/lib/python2.7/site-packages/prance/util/resolver.py", line 92, in resolve_references
    changes = tuple(self._dereferencing_iterator(self.specs))
  File "/usr/local/lib/python2.7/site-packages/prance/util/resolver.py", line 59, in _dereferencing_iterator
    _, ref_path, referenced = self._dereference(refstring)
  File "/usr/local/lib/python2.7/site-packages/prance/util/resolver.py", line 115, in _dereference
    parsed_url, referenced = self._fetch_url(parsed_url)
  File "/usr/local/lib/python2.7/site-packages/prance/util/resolver.py", line 149, in _fetch_url
    resolver = RefResolver(_url.fetch_url(url), url)
  File "/usr/local/lib/python2.7/site-packages/prance/util/url.py", line 115, in fetch_url
    content = read_file(from_posix(url.path))
  File "/usr/local/lib/python2.7/site-packages/prance/util/fs.py", line 179, in read_file
    encoding = detect_encoding(filename)
  File "/usr/local/lib/python2.7/site-packages/prance/util/fs.py", line 125, in detect_encoding
    file_len = os.path.getsize(filename)
  File "/usr/local/lib/python2.7/genericpath.py", line 57, in getsize
    return os.stat(filename).st_size
OSError: [Errno 2] No such file or directory: '/tmp/tmpMS0IjJ/responses.yaml'
```

That's because the file `responses.yaml` is now used in references, but we don't pull it yet.