### PR TITLE
Patch urllib to 1.24.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ semver==2.8.1
 six==1.12.0
 soupsieve==1.7.3
 toml==0.10.0
-urllib3==1.24.1
+urllib3==1.24.2
 openapi-spec-validator==0.2.4


### PR DESCRIPTION
Due to a security vulnerability in 1.24.1 (https://nvd.nist.gov/vuln/detail/CVE-2019-11324)