### PR TITLE
Fix docs indexing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.7-alpine3.9
 ENV PYTHON_UNBUFFERED 1
 ENV PYTHONWARNINGS "ignore:Unverified HTTPS request"
 
-RUN apk add --update git && rm -rf /var/cache/apk/*
+RUN apk add --update git ca-certificates && rm -rf /var/cache/apk/*
 
 ADD requirements.txt /
 RUN pip install -r /requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,10 @@ chardet==3.0.4
 elasticsearch==1.9.0
 idna==2.8
 Markdown==2.6.11
+openapi-spec-validator==0.2.7
 prance==0.14.0
-PyYAML==4.2b4
-requests==2.21.0
+requests==2.22.0
 semver==2.8.1
 six==1.12.0
 soupsieve==1.7.3
 toml==0.10.0
-urllib3==1.25.2
-openapi-spec-validator==0.2.4


### PR DESCRIPTION
This PR fixes two problems that made docs indexing impossible:

- CA certificates where missing
- The `openapi_spec_validator` lib produced an error `AttributeError: module 'jsonschema._validators' has no attribute 'properties_draft4'`