### PR TITLE
Support YAML front matter in docs indexer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,14 +12,20 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Run Python unit tests
+          command: make test
+
+      - run:
           name: Install architect
           command: |
             wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
             chmod +x ./architect
             ./architect version
+
       - run:
           name: architect build
           command: ./architect build
+
       - deploy:
           name: architect deploy (master only)
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,9 @@ jobs:
       - checkout
       - run:
           name: Run Python unit tests
-          command: make test
+          command: |
+            pip install -r requirements.txt
+            python indexer_test.py
 
       - run:
           name: Install architect

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,11 @@ build:
 
 run:
 	docker run --rm -ti quay.io/giantswarm/docs-indexer
+
+venv:
+	virtualenv venv -p python3
+	source venv/bin/activate
+	pip install -r requirements.txt
+
+test: venv
+	venv/bin/python indexer_test.py

--- a/indexer_test.py
+++ b/indexer_test.py
@@ -1,0 +1,55 @@
+import unittest
+from indexer import get_front_matter
+
+doc_with_yaml_front_matter = """---
+title: Node Pools
+description: A general description of node pools as a concept, it's benefits, and some details you should be aware of.
+date: 2019-12-19
+weight: 130
+type: page
+categories: ["basics"]
+---
+
+This is the YAML example's text
+"""
+
+doc_with_toml_front_matter = """+++
+title = "The Giant Swarm App Catalog"
+description = "Overview of the Giant Swarm App Catalog, how it works and what to expect."
+date = "2019-02-11"
+weight = 90
+type = "page"
+categories = ["basics"]
++++
+
+This is the TOML example's text
+"""
+
+doc_without_front_matter = """# Headline 1
+
+The _Giant Swarm App Catalog_ refers to a set of features and concepts that allow
+you to browse, install and manage the configurations of apps (such as prometheus)
+from a single place; the Control Plane.
+"""
+
+
+
+class TestFrontMatter(unittest.TestCase):
+
+    def test_get_front_matter_toml(self):
+        data, text = get_front_matter(doc_with_toml_front_matter, "tomlpath")
+        self.assertEqual(data["title"], "The Giant Swarm App Catalog")
+        self.assertEqual(text, "This is the TOML example's text")
+
+    def test_get_front_matter_yaml(self):
+        data, text = get_front_matter(doc_with_yaml_front_matter, "yamlpath")
+        self.assertEqual(data["title"], "Node Pools")
+        self.assertEqual(text, "This is the YAML example's text")
+    
+    def test_get_front_matter_none(self):
+        data, text = get_front_matter(doc_without_front_matter, "nonepath")
+        self.assertIs(data, None)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This should fix the problem that some pages are using YAML front matter and as a consequence don't appear in search results.

Also introducing unit tests and `make test` for the first time.