### PR TITLE
Be easy when repo dir already exists

### DIFF
--- a/indexer.py
+++ b/indexer.py
@@ -86,7 +86,7 @@ def clone_repos(repo_url, branch):
                 (reponame, _) = os.path.basename(repo_url).split(".")
                 path = os.path.join(SOURCE_PATH, reponame)
                 logging.info("Cloning repository %s to %s" % (reponame, path))
-                os.makedirs(path)
+                os.makedirs(path, exist_ok=True)
                 cmd = ["git", "clone", "-q",
                        "--depth", "1",
                        repo_url, path]


### PR DESCRIPTION
Prevent an error when an external repo has been cloned in the container before.

To mitigate this error when re-using the container:

![image](https://user-images.githubusercontent.com/273727/77901150-69395700-727f-11ea-975e-9068afa93850.png)
