### PR TITLE
Index CRDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There is a helm chart in the `helm` subfolder.
 
 The following environment variables are supported for configuration:
 
-- `REPOSITORY_URL`: Git repo URL to clone, e. g. `https://github.com/giantswarm/docs-content.git`
+- `REPOSITORY_URL`: Git repo URL to clone, e. g. `https://github.com/giantswarm/docs.git`
 - `REPOSITORY_BRANCH`: Defaults to `master`
 - `REPOSITORY_SUBFOLDER`: Only look into this path within the repository for indexable content
 - `EXTERNAL_REPOSITORY_SUBFOLDER`: Only look into this path within external repositories for indexable content
@@ -27,3 +27,7 @@ The following environment variables are supported for configuration:
 
 The search mapping for the documents created can be found in `mapping.json`.
 
+## Usage
+
+[This docker-compose configuration](https://github.com/giantswarm/docs/blob/master/docker-compose.yaml)
+shows how to use the container.

--- a/indexer.py
+++ b/indexer.py
@@ -447,12 +447,6 @@ def collect_properties_text(schema_dict):
         for prop in schema_dict["properties"].keys():
             ret.append(prop)
             ret.extend(collect_properties_text(schema_dict["properties"][prop]))
-            # if "type" in schema_dict["properties"][prop]:
-            #     if schema_dict["properties"][prop]["type"] == "object":
-            #         ret.extend(collect_properties_text(schema_dict["properties"][prop]))
-            #     if schema_dict["properties"][prop]["type"] == "array":
-            #         if "items" in schema_dict["properties"][prop]:
-            #             ret.extend(collect_properties_text(schema_dict["properties"][prop]["items"]))
     return ret
 
 


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/10544

This enables the indexer to index CRD content.

The configuration regarding which apiextensions version should be indexed is taken from the `docs` repo `master` ([this file](https://github.com/giantswarm/docs/blob/master/crd-docs-generator-config.yaml)).

While it is possible that whatever is published at https://docs.giantswarm.io/ differs from docs 
`master`, the effect of such a change should be marginal and should only be temporary.

### Peview

![image](https://user-images.githubusercontent.com/273727/81297781-1324b400-9074-11ea-81d5-484aecdff0da.png)
