### PR TITLE
Simplify indexer, fix some bugs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
           name: Run Python unit tests
           command: |
             pip install -r requirements.txt
+            python --version
             python indexer_test.py
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     machine:
       docker_layer_caching: true
-      image: "ubuntu-1604:201903-01"
+      image: "cimg/python:3.9"
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run:
           name: Run Python unit tests
           command: |
-            pip install -r requirements.txt
+            pip3 install -r requirements.txt
             python3 --version
             python3 indexer_test.py
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     machine:
       docker_layer_caching: true
-      image: "cimg/python:3.9"
+      image: "ubuntu-2004:202010-01"
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ workflows:
             tags:
               only: /.*/
       - architect/push-to-app-catalog:
-          name: "package and push giantswarmio-nginx"
+          name: "package and push docs-indexer-app"
           app_catalog: "giantswarm-operations-platform-catalog"
           app_catalog_test: "giantswarm-operations-platform-test-catalog"
           chart: "docs-indexer-app"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ jobs:
           name: Run Python unit tests
           command: |
             pip install -r requirements.txt
-            python --version
-            python indexer_test.py
+            python3 --version
+            python3 indexer_test.py
 
       - run:
           name: Install architect

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN set -x \
 RUN apk add --no-cache --update git ca-certificates yaml-dev build-base
 
 ADD requirements.txt /
-RUN pip install --upgrade pip
-RUN pip install --global-option='--with-libyaml' pyyaml
-RUN pip install -r /requirements.txt
+RUN pip install --upgrade pip && \
+    pip install --global-option='--with-libyaml' pyyaml && \
+    pip install -r /requirements.txt
 
 WORKDIR /app
 COPY indexer.py /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine3.12
+FROM python:3.9-alpine
 
 ENV PYTHON_UNBUFFERED 1
 ENV PYTHONWARNINGS "ignore:Unverified HTTPS request"
@@ -8,10 +8,11 @@ RUN set -x \
     && addgroup -g 101 -S indexer \
     && adduser -S -D -u 101 -h /home/indexer -s /sbin/nologin -G indexer -g indexer indexer
 
-RUN apk add --no-cache --update git ca-certificates
+RUN apk add --no-cache --update git ca-certificates yaml-dev build-base
 
 ADD requirements.txt /
 RUN pip install --upgrade pip
+RUN pip install --global-option='--with-libyaml' pyyaml
 RUN pip install -r /requirements.txt
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ Here is some additional information on the index fields:
 - `uri`: The URI of the page, starting with a slash (/), so not containing schema or hostname. Used as unique identifier, so there cannot be two entries with the same `uri` value.
 - `breadcrumb`: List field for breadcrumb items. For a page with `uri = "/foo/bar/"` this will be `["foo", "bar"]`.
 - `breadcrumb_1` to `breadcrumb_n`: Individual fields for the first, second, third, ... nth breadcrumb item.
-- `title`: The title of the document, as intended for representation as a main headline of a search result item. If a document provides several titles, this is supposed to be what users would consider the main headline of the article, or what contains the most valuabl content to search for.
+- `title`: The title of the document, as intended for representation as a main headline of a search result item. If a document provides several titles, this is supposed to be what users would consider the main headline of the article, or what contains the most valuable content to search for.
 - `body`: All text from the main page, excluding the first headline (which is expected to resemble the `title` content).
 - `text`: catch-all field. Used for generic search queries where no specific field is selected for a match.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # docs-indexer
 
-Indexes content for the search engine of [docs.giantswarm.io](https://docs.giantswarm.io).
+Indexes content for the search engine of [docs.giantswarm.io](https://docs.giantswarm.io/).
 
 As a source, this takes a public GitHub repository. As a target, an Elasticsearch API endpoint is used.
 
@@ -31,3 +31,16 @@ The search mapping for the documents created can be found in `mapping.json`.
 
 [This docker-compose configuration](https://github.com/giantswarm/docs/blob/master/docker-compose.yaml)
 shows how to use the container.
+
+## Elasticsearch schema
+
+This indexer creates an Elasticsearch index with the mapping defined in the file `mapping.json`.
+
+Here is some additional information on the index fields:
+
+- `uri`: The URI of the page, starting with a slash (/), so not containing schema or hostname. Used as unique identifier, so there cannot be two entries with the same `uri` value.
+- `breadcrumb`: List field for breadcrumb items. For a page with `uri = "/foo/bar/"` this will be `["foo", "bar"]`.
+- `breadcrumb_1` to `breadcrumb_n`: Individual fields for the first, second, third, ... nth breadcrumb item.
+- `title`: The title of the document, as intended for representation as a main headline of a search result item. If a document provides several titles, this is supposed to be what users would consider the main headline of the article, or what contains the most valuabl content to search for.
+- `body`: All text from the main page, excluding the first headline (which is expected to resemble the `title` content).
+- `text`: catch-all field. Used for generic search queries where no specific field is selected for a match.

--- a/indexer.py
+++ b/indexer.py
@@ -8,13 +8,11 @@ from prance import ResolvingParser
 import json
 import logging
 import os
-from pprint import pprint
 import re
 import shutil
 import signal
 import sys
 import time
-import toml
 import tempfile
 import urllib3
 import yaml
@@ -25,7 +23,6 @@ except ImportError:
     print("WARNING: Using pure python YAML without accelaration of C libraries")
     from yaml import Loader
 
-from pprint import pprint
 
 ELASTICSEARCH_INDEX_NAME = os.getenv("ELASTICSEARCH_INDEX_NAME", "docs")
 ELASTICSEARCH_MAPPING = json.load(open("mapping.json", "rb"))
@@ -230,7 +227,6 @@ def index_openapi_spec(uri, base_path, spec_files, index):
 
     # parse spec
     parser = ResolvingParser(tmpdir + os.path.sep + os.path.basename(files[0]))
-    #pprint.pprint(parser.specification["paths"])
 
     for path in parser.specification["paths"]:
         for method in parser.specification["paths"][path]:

--- a/indexer_test.py
+++ b/indexer_test.py
@@ -13,18 +13,6 @@ categories: ["basics"]
 This is the YAML example's text
 """
 
-doc_with_toml_front_matter = """+++
-title = "The Giant Swarm App Catalog"
-description = "Overview of the Giant Swarm App Catalog, how it works and what to expect."
-date = "2019-02-11"
-weight = 90
-type = "page"
-categories = ["basics"]
-+++
-
-This is the TOML example's text
-"""
-
 doc_without_front_matter = """# Headline 1
 
 The _Giant Swarm App Catalog_ refers to a set of features and concepts that allow
@@ -35,11 +23,6 @@ from a single place; the Control Plane.
 
 
 class TestFrontMatter(unittest.TestCase):
-
-    def test_get_front_matter_toml(self):
-        data, text = get_front_matter(doc_with_toml_front_matter, "tomlpath")
-        self.assertEqual(data["title"], "The Giant Swarm App Catalog")
-        self.assertEqual(text, "This is the TOML example's text")
 
     def test_get_front_matter_yaml(self):
         data, text = get_front_matter(doc_with_yaml_front_matter, "yamlpath")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,9 @@ idna==2.8
 Markdown==2.6.11
 openapi-spec-validator==0.2.7
 prance==0.14.0
-requests==2.22.0
+requests==2.25.0
 semver==2.8.1
 six==1.12.0
 soupsieve==1.7.3
 toml==0.10.0
+urllib3==1.26.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,4 @@ requests==2.25.0
 semver==2.8.1
 six==1.12.0
 soupsieve==1.7.3
-toml==0.10.0
 urllib3==1.26.2


### PR DESCRIPTION
This PR does

- Remove the pulling of external repositories and special handling of CRDs. This is no longer necessary as of https://github.com/giantswarm/docs/pull/660. Also closes https://github.com/giantswarm/giantswarm/issues/10376
- Adapt the front matter parsing, to mitigate a problem with changelog entries showing up without title and `undefined` instead. A step towards https://github.com/giantswarm/giantswarm/issues/14577.
- Update the base image and enable the use of lib-yaml for faster parsing
- Remove support for parsing TOML front matter, as we only use YAML by now