### PR TITLE
Add settings for additional fields used by phrase suggester

### DIFF
--- a/indexer.py
+++ b/indexer.py
@@ -352,7 +352,32 @@ if __name__ == "__main__":
         index=tempindex,
         body={
             "settings" : {
-                "number_of_shards" : 1,
+                "index": {
+                    "number_of_shards" : 1,
+                    "analysis": {
+                        "analyzer": {
+                            # 'trigram' and 'reverse' analyzers needed for phrase suggester. See mapping.json.
+                            "trigram": {
+                                "type": "custom",
+                                "tokenizer": "standard",
+                                "filter": ["lowercase", "shingle"]
+                            },
+                            "reverse": {
+                                "type": "custom",
+                                "tokenizer": "standard",
+                                "filter": ["lowercase", "reverse"]
+                            }
+                        },
+                        "filter": {
+                            # 'shingle' filter needed by 'trigram' analyzer.
+                            "shingle": {
+                                "type": "shingle",
+                                "min_shingle_size": 2,
+                                "max_shingle_size": 3
+                            }
+                        }
+                    }
+                }
             },
             "mappings": ELASTICSEARCH_MAPPING
         },

--- a/mapping.json
+++ b/mapping.json
@@ -23,8 +23,21 @@
     "text": {
       "type": "text",
       "store": true,
-      "term_vector": "with_positions_offsets",
-      "analyzer": "english"
+      "fields": {
+        "english": {
+          "type": "text",
+          "term_vector": "with_positions_offsets",
+          "analyzer": "english"
+        },
+        "trigram": {
+          "type": "text",
+          "analyzer": "trigram"
+        },
+        "reverse": {
+          "type": "text",
+          "analyzer": "reverse"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14703

This PR adds backward-compatible changes to the Elasticsearch index configuration, which will then be used by a more advanced search to get "phrase suggestions" back, as described in https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-suggesters-phrase.html

This is required to enable the functionality added in https://github.com/giantswarm/docs/pull/716