### PR TITLE
Add date field to search indizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,5 @@ Here is some additional information on the index fields:
 - `title`: The title of the document, as intended for representation as a main headline of a search result item. If a document provides several titles, this is supposed to be what users would consider the main headline of the article, or what contains the most valuable content to search for.
 - `body`: All text from the main page, excluding the first headline (which is expected to resemble the `title` content).
 - `text`: catch-all field. Used for generic search queries where no specific field is selected for a match.
+- `date`: Publish date or last modification date for the entry.
 - `image_uri`: URL of an image for the entry (optional).
-- `published`: Publish date for the entry (optional).

--- a/blog.py
+++ b/blog.py
@@ -81,7 +81,7 @@ def parse_blog_post(post):
         'breadcrumb': ['blog'],
         'breadcrumb_1': 'blog',
         'uri': post['url'],
-        'published': parse_date(post['created']),
+        'date': parse_date(post['created']),
         'title': title,
         'image_uri': post['featuredImage'],
         'body': body,

--- a/docs.py
+++ b/docs.py
@@ -218,13 +218,8 @@ def index_page(es, root_path, path, breadcrumb, uri, index, last_modified):
     data["breadcrumb"] = breadcrumb
     data["body"] = text
 
-    data["date"] = DEFAULT_DATE.isoformat() + "+00:00"
-
     relative_path = path[len(root_path + "/"):]
-    if relative_path in last_modified:
-        data["date"] = last_modified[relative_path].isoformat() + "+00:00"
-    else:
-        logging.info(f"File {relative_path} not contained in last_modified")
+    data["date"] = last_modified.get(relative_path, DEFAULT_DATE.isoformat() + "+00:00")
 
     # catch-all text field
     if "title" in data:

--- a/mappings/blog.json
+++ b/mappings/blog.json
@@ -24,7 +24,7 @@
       "term_vector": "with_positions_offsets",
       "analyzer": "english"
     },
-    "published": {
+    "date": {
       "type": "date"
     },
     "text": {

--- a/mappings/docs.json
+++ b/mappings/docs.json
@@ -20,6 +20,9 @@
       "term_vector": "with_positions_offsets",
       "analyzer": "english"
     },
+    "date": {
+      "type": "date"
+    },
     "text": {
       "type": "text",
       "store": true,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ certifi==2018.11.29
 chardet==3.0.4
 click==7.1.2
 elasticsearch==6.8.2
+GitPython==3.1.14
 idna==2.8
 Markdown==2.6.11
 openapi-spec-validator==0.2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4==4.7.1
+beautifulsoup4==4.9.3
 certifi==2018.11.29
 chardet==3.0.4
 click==7.1.2
@@ -9,7 +9,7 @@ Markdown==2.6.11
 openapi-spec-validator==0.2.7
 prance==0.14.0
 requests==2.25.1
-semver==2.8.1
-six==1.12.0
+semver==2.13.0
+six==1.16.0
 soupsieve==1.7.3
 urllib3==1.26.4


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16853

This renames the "published" field in the blog index to "date". And it adds a "date" field to the "docs" index.

For api-spec entries, we use a default date, since there is no individual last modification date for them.

As a result, all entries get a date, so we can use a decay function to rank results.
