### PR TITLE
Speed up docs-indexer by increasing CPU limit

### DIFF
--- a/helm/docs-indexer-app/templates/cronjob.yaml
+++ b/helm/docs-indexer-app/templates/cronjob.yaml
@@ -49,10 +49,10 @@ spec:
                   mountPath: /home/indexer/gitcache
               resources:
                 requests:
-                  cpu: 100m
+                  cpu: 500m
                   memory: 100M
                 limits:
-                  cpu: 100m
+                  cpu: 500m
                   memory: 100M
           volumes:
             - name: cache

--- a/helm/docs-indexer-app/templates/cronjob.yaml
+++ b/helm/docs-indexer-app/templates/cronjob.yaml
@@ -52,8 +52,8 @@ spec:
                   cpu: 500m
                   memory: 100M
                 limits:
-                  cpu: 500m
-                  memory: 100M
+                  cpu: 1000m
+                  memory: 500M
           volumes:
             - name: cache
               emptyDir: {}
@@ -113,8 +113,8 @@ spec:
                   cpu: 500m
                   memory: 100M
                 limits:
-                  cpu: 500m
-                  memory: 100M
+                  cpu: 100m
+                  memory: 500M
           restartPolicy: OnFailure
           serviceAccount: {{ .Values.name }}
           serviceAccountName: {{ .Values.name }}

--- a/helm/docs-indexer-app/templates/cronjob.yaml
+++ b/helm/docs-indexer-app/templates/cronjob.yaml
@@ -110,10 +110,10 @@ spec:
                       key: hubspot-api-key
               resources:
                 requests:
-                  cpu: 100m
+                  cpu: 500m
                   memory: 100M
                 limits:
-                  cpu: 100m
+                  cpu: 500m
                   memory: 100M
           restartPolicy: OnFailure
           serviceAccount: {{ .Values.name }}


### PR DESCRIPTION
The indexers seem to take longer than needed. Since these are jobs, we should not be too restrictive.