### PR TITLE
Change apiversion

### DIFF
--- a/helm/docs-indexer-app/templates/cronjob.yaml
+++ b/helm/docs-indexer-app/templates/cronjob.yaml
@@ -1,6 +1,6 @@
 ---
 # Indexer cronjob for docs, api-spec
-apiVersion: batch/v2alpha1
+apiVersion: batch/v1beta1
 kind: CronJob
 
 metadata:
@@ -62,7 +62,7 @@ spec:
           serviceAccountName: {{ .Values.name }}
 ---
 # Indexer cronjob for blog posts
-apiVersion: batch/v2alpha1
+apiVersion: batch/v1beta1
 kind: CronJob
 
 metadata:


### PR DESCRIPTION
batch/v2alpha1 has been removed in k8s 1.21 it is now batch/v1 as GA.

This changes the apiVersion to v2beta1 for the transition period.
