### PR TITLE
Add type field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Improve docker image build speed by using PyYAML from Alpine.
+- Add `type` field to search documents for filtering.
 
 ## [3.0.1] - 2022-12-15
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The following environment variables are required for configuration, by sub comma
 - `REPOSITORY_HANDLE`: Github organization and repository name in the format `org/repo`.
 - `REPOSITORY_BRANCH`: Defaults to `main`.
 - `REPOSITORY_SUBFOLDER`: Only look into this path within the repository for indexable content.
+- `TYPE_LABEL`: User friendly search result type name.
 - `APIDOCS_BASE_URI`: Base URI for API documentation. Should be `https://docs.giantswarm.io/api/`.
 - `APIDOCS_BASE_PATH`: Should be `/api/`
 - `API_SPEC_FILES`: Comma separated list of YAML files to fetch for the OpenAPI spec.
@@ -46,6 +47,7 @@ This indexers create Elasticsearch indices with the mappings defined in the file
 
 Here is some additional information on the index fields:
 
+- `type`: Document type in a user-friendly spelling, used for filtering.
 - `url`: Full URL of the resource.
 - `breadcrumb`: List field for breadcrumb items. For a page with `URL = "https://example.com/foo/bar/"` this will be `["foo", "bar"]`.
 - `breadcrumb_1` to `breadcrumb_n`: Individual fields for the first, second, third, ... nth breadcrumb item.

--- a/blog.py
+++ b/blog.py
@@ -32,7 +32,10 @@ HUBSPOT_ENDPOINT = 'https://api.hubapi.com'
 TIME_FORMAT_FINE = '%Y-%m-%dT%H:%M:%S.%fZ'
 TIME_FORMAT_COARSE = '%Y-%m-%dT%H:%M:%SZ'
 TIME_FORMAT_INDEXNAME = '%Y-%m-%d-%H-%M-%S'
-INDEX_MAPPING = json.load(open('mappings/blog.json', 'rb'))
+TYPE_LABEL = 'Blog'
+
+with open('mappings/blog.json', 'rb') as f:
+    INDEX_MAPPING = json.load(f)
 
 # Name prefix and alias for our index. Must not contain dashes!
 INDEX_NAME_PREFIX = 'blog'
@@ -79,6 +82,7 @@ def parse_blog_post(post):
 
     ret = {
         'id': post['id'],
+        'type': TYPE_LABEL,
         'breadcrumb': ['blog'],
         'breadcrumb_1': 'blog',
         'url': post['url'],

--- a/helm/docs-indexer-app/templates/cronjob-docs.yaml
+++ b/helm/docs-indexer-app/templates/cronjob-docs.yaml
@@ -53,6 +53,8 @@ spec:
                   value: src/content
                 - name: INDEX_NAME
                   value: docs
+                - name: TYPE_LABEL
+                  value: Documentation
               volumeMounts:
                 - name: docs-cache
                   mountPath: /home/indexer/gitcache

--- a/helm/docs-indexer-app/templates/cronjob-handbook.yaml
+++ b/helm/docs-indexer-app/templates/cronjob-handbook.yaml
@@ -53,6 +53,8 @@ spec:
                   value: content
                 - name: INDEX_NAME
                   value: handbook
+                - name: TYPE_LABEL
+                  value: Handbook
               volumeMounts:
                 - name: handbook-cache
                   mountPath: /home/indexer/gitcache

--- a/helm/docs-indexer-app/templates/cronjob-intranet.yaml
+++ b/helm/docs-indexer-app/templates/cronjob-intranet.yaml
@@ -55,6 +55,8 @@ spec:
                   value: content/docs
                 - name: INDEX_NAME
                   value: intranet
+                - name: TYPE_LABEL
+                  value: Intranet
               volumeMounts:
                 - name: intranet-cache
                   mountPath: /home/indexer/gitcache

--- a/hugo.py
+++ b/hugo.py
@@ -41,6 +41,9 @@ REPOSITORY_HANDLE = os.getenv("REPOSITORY_HANDLE")
 # TODO: validate
 INDEX_NAME = os.getenv("INDEX_NAME")
 
+# TODO: validate
+TYPE_LABEL = os.getenv("TYPE_LABEL")
+
 # TODO: remove
 APIDOCS_BASE_URI = os.getenv("APIDOCS_BASE_URI")
 APIDOCS_BASE_PATH = os.getenv("APIDOCS_BASE_PATH")
@@ -231,6 +234,7 @@ def index_page(es, root_path, path, breadcrumb, uri, index, last_modified):
         logging.warning("File in %s did not provide parseable front matter." % path)
         data = {}
     
+    data["type"] = TYPE_LABEL
     data["uri"] = uri
     data["url"] = (BASE_URL + uri).replace("//", "/")
     data["breadcrumb"] = breadcrumb

--- a/mappings/blog.json
+++ b/mappings/blog.json
@@ -6,6 +6,10 @@
       "term_vector": "with_positions_offsets",
       "analyzer": "english"
     },
+    "type": {
+      "type": "keyword",
+      "store": true
+    },
     "url": {
       "type": "keyword",
       "store": true

--- a/mappings/hugo.json
+++ b/mappings/hugo.json
@@ -6,6 +6,10 @@
       "term_vector": "with_positions_offsets",
       "analyzer": "english"
     },
+    "type": {
+      "type": "keyword",
+      "store": true
+    },
     "url": {
       "type": "keyword",
       "store": true


### PR DESCRIPTION
This field will enabling filtering by source/type of document.

For the HUGO indexers we configure the type via the `TYPE_LABEL` env variable.

For the blog indexer we just hardcode it to `Blog`.