### PR TITLE
Fix secret reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix reference to secret in Role resource
+
 ## [3.4.0] - 2024-02-09
 
 ### Changed

--- a/helm/docs-indexer-app/templates/rbac.yaml
+++ b/helm/docs-indexer-app/templates/rbac.yaml
@@ -25,7 +25,7 @@ rules:
   resources:
   - secrets
   resourceNames:
-  - hubspot-access-token
+  - {{ .Values.name }}-credentials
   verbs:
   - get
 ---


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29470

This PR fixes an outdated secret name in an RBAC Role.