### PR TITLE
Enable indexing to OpenSearch v2.16

### DIFF
--- a/blog.py
+++ b/blog.py
@@ -176,6 +176,12 @@ def run():
     if OPENSEARCH_ENDPOINT is None:
         logging.error("OPENSEARCH_ENDPOINT isn't configured.")
         sys.exit(1)
+    if OPENSEARCH_USERNAME is None:
+        logging.error("OPENSEARCH_USERNAME isn't configured.")
+        sys.exit(1)
+    if OPENSEARCH_PASSWORD is None or OPENSEARCH_PASSWORD == "DUMMYPASS":
+        logging.error("OPENSEARCH_PASSWORD isn't configured.")
+        sys.exit(1)
     
     # give OpenSearch some time
     sleep(3)

--- a/common.py
+++ b/common.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup
 
-# Common settings for all elasticsearch indexes
+# Common settings for all OpenSearch indexes
 index_settings = {
     "index": {
         "number_of_shards" : 1,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ The following environment variables are accepted, by indexer sub command:
 
 ## `hugo`
 
-- `ELASTICSEARCH_ENDPOINT`: URI for the Elasticsearch API endpoint.
+- `OPENSEARCH_ENDPOINT`: URI for the OpenSearch API endpoint.
 - `GITHUB_TOKEN`: If the repo is private, use this access token.
 - `INDEX_NAME`: Name of the search index to maintain.
 - `BASE_URL`: URL corresponding to the published root page of the site.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,6 +1,6 @@
 # Search index schema
 
-This indexers create Elasticsearch indices with the mappings defined in the files `/mappings/*.json`.
+This indexers create OpenSearch indices with the mappings defined in the files `/mappings/*.json`.
 
 Here is some additional information on the index fields:
 

--- a/helm/docs-indexer-app/templates/cronjob-blog.yaml
+++ b/helm/docs-indexer-app/templates/cronjob-blog.yaml
@@ -51,6 +51,16 @@ spec:
               env:
                 - name: OPENSEARCH_ENDPOINT
                   value: {{ .Values.opensearchEndpoint }}
+                - name: OPENSEARCH_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.name }}-credentials
+                      key: opensearch-user-name
+                - name: OPENSEARCH_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.name }}-credentials
+                      key: opensearch-password
                 - name: HUBSPOT_ACCESS_TOKEN
                   valueFrom:
                     secretKeyRef:

--- a/helm/docs-indexer-app/templates/cronjob-blog.yaml
+++ b/helm/docs-indexer-app/templates/cronjob-blog.yaml
@@ -49,8 +49,8 @@ spec:
                 seccompProfile:
                   type: RuntimeDefault
               env:
-                - name: ELASTICSEARCH_ENDPOINT
-                  value: {{ .Values.elasticsearchEndpoint }}
+                - name: OPENSEARCH_ENDPOINT
+                  value: {{ .Values.opensearchEndpoint }}
                 - name: HUBSPOT_ACCESS_TOKEN
                   valueFrom:
                     secretKeyRef:

--- a/helm/docs-indexer-app/templates/cronjob-docs.yaml
+++ b/helm/docs-indexer-app/templates/cronjob-docs.yaml
@@ -54,6 +54,16 @@ spec:
               env:
                 - name: OPENSEARCH_ENDPOINT
                   value: {{ .Values.opensearchEndpoint }}
+                - name: OPENSEARCH_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.name }}-credentials
+                      key: opensearch-user-name
+                - name: OPENSEARCH_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.name }}-credentials
+                      key: opensearch-password
                 - name: BASE_URL
                   value: https://docs.giantswarm.io
                 - name: REPOSITORY_HANDLE

--- a/helm/docs-indexer-app/templates/cronjob-docs.yaml
+++ b/helm/docs-indexer-app/templates/cronjob-docs.yaml
@@ -52,8 +52,8 @@ spec:
                 seccompProfile:
                   type: RuntimeDefault
               env:
-                - name: ELASTICSEARCH_ENDPOINT
-                  value: {{ .Values.elasticsearchEndpoint }}
+                - name: OPENSEARCH_ENDPOINT
+                  value: {{ .Values.opensearchEndpoint }}
                 - name: BASE_URL
                   value: https://docs.giantswarm.io
                 - name: REPOSITORY_HANDLE

--- a/helm/docs-indexer-app/templates/cronjob-handbook.yaml
+++ b/helm/docs-indexer-app/templates/cronjob-handbook.yaml
@@ -54,6 +54,16 @@ spec:
               env:
                 - name: OPENSEARCH_ENDPOINT
                   value: {{ .Values.opensearchEndpoint }}
+                - name: OPENSEARCH_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.name }}-credentials
+                      key: opensearch-user-name
+                - name: OPENSEARCH_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.name }}-credentials
+                      key: opensearch-password
                 - name: BASE_URL
                   value: https://handbook.giantswarm.io
                 - name: REPOSITORY_HANDLE

--- a/helm/docs-indexer-app/templates/cronjob-handbook.yaml
+++ b/helm/docs-indexer-app/templates/cronjob-handbook.yaml
@@ -52,8 +52,8 @@ spec:
                 seccompProfile:
                   type: RuntimeDefault
               env:
-                - name: ELASTICSEARCH_ENDPOINT
-                  value: {{ .Values.elasticsearchEndpoint }}
+                - name: OPENSEARCH_ENDPOINT
+                  value: {{ .Values.opensearchEndpoint }}
                 - name: BASE_URL
                   value: https://handbook.giantswarm.io
                 - name: REPOSITORY_HANDLE

--- a/helm/docs-indexer-app/templates/cronjob-intranet.yaml
+++ b/helm/docs-indexer-app/templates/cronjob-intranet.yaml
@@ -49,8 +49,8 @@ spec:
                 seccompProfile:
                   type: RuntimeDefault
               env:
-                - name: ELASTICSEARCH_ENDPOINT
-                  value: {{ .Values.elasticsearchEndpoint }}
+                - name: OPENSEARCH_ENDPOINT
+                  value: {{ .Values.opensearchEndpoint }}
                 - name: BASE_URL
                   value: https://intranet.giantswarm.io/docs
                 - name: GITHUB_TOKEN

--- a/helm/docs-indexer-app/templates/cronjob-intranet.yaml
+++ b/helm/docs-indexer-app/templates/cronjob-intranet.yaml
@@ -51,6 +51,16 @@ spec:
               env:
                 - name: OPENSEARCH_ENDPOINT
                   value: {{ .Values.opensearchEndpoint }}
+                - name: OPENSEARCH_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.name }}-credentials
+                      key: opensearch-user-name
+                - name: OPENSEARCH_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.name }}-credentials
+                      key: opensearch-password
                 - name: BASE_URL
                   value: https://intranet.giantswarm.io/docs
                 - name: GITHUB_TOKEN

--- a/helm/docs-indexer-app/templates/secret.yaml
+++ b/helm/docs-indexer-app/templates/secret.yaml
@@ -10,3 +10,5 @@ type: Opaque
 data:
   github-access-token: {{ .Values.credentials.githubAccessToken | b64enc }}
   hubspot-access-token: {{ .Values.credentials.hubspotAccessToken | b64enc }}
+  opensearch-user-name: {{ .Values.credentials.opensearchUsername | b64enc }}
+  opensearch-password: {{ .Values.credentials.opensearchPassword | b64enc }}

--- a/helm/docs-indexer-app/values.yaml
+++ b/helm/docs-indexer-app/values.yaml
@@ -18,6 +18,8 @@ resources:
 credentials:
   githubAccessToken: DUMMYTOKEN
   hubspotAccessToken: DUMMYTOKEN
+  opensearchUsername: admin
+  opensearchPassword: DUMMYPASS
 
 global:
   podSecurityStandards:

--- a/helm/docs-indexer-app/values.yaml
+++ b/helm/docs-indexer-app/values.yaml
@@ -5,7 +5,7 @@ image:
   name: docs-indexer
   tag: "[[.Version]]"
   sha: "[[.SHA]]"
-elasticsearchEndpoint: "http://sitesearch-app:9200/"
+opensearchEndpoint: "http://sitesearch-app:9200/"
 
 resources:
   requests:

--- a/hugo.py
+++ b/hugo.py
@@ -27,7 +27,7 @@ from common import index_settings
 
 OPENSEARCH_ENDPOINT = os.getenv("OPENSEARCH_ENDPOINT", "http://localhost:9200/")
 OPENSEARCH_USERNAME = os.getenv("OPENSEARCH_USERNAME", "admin")
-OPENSEARCH_PASSWORD = os.getenv("OPENSEARCH_PASSWORD", "")
+OPENSEARCH_PASSWORD = os.getenv("OPENSEARCH_PASSWORD")
 
 REPOSITORY_BRANCH = os.getenv("REPOSITORY_BRANCH", "main")
 REPOSITORY_SUBFOLDER = os.getenv("REPOSITORY_SUBFOLDER")
@@ -418,6 +418,12 @@ def run():
 
     if OPENSEARCH_ENDPOINT is None:
         logging.error("OPENSEARCH_ENDPOINT isn't configured.")
+        sys.exit(1)
+    if OPENSEARCH_USERNAME is None:
+        logging.error("OPENSEARCH_USERNAME isn't configured.")
+        sys.exit(1)
+    if OPENSEARCH_PASSWORD is None or OPENSEARCH_PASSWORD == "DUMMYPASS":
+        logging.error("OPENSEARCH_PASSWORD isn't configured.")
         sys.exit(1)
 
     # give OpenSearch some time

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ beautifulsoup4==4.12.3
 certifi==2024.7.4
 chardet==5.2.0
 click==8.1.7
-elasticsearch==6.8.2
+opensearch-py==2.6.0
 GitPython==3.1.43
 idna==3.7
 Markdown==3.6


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26502

This PR updates our indexing code, which so far was used against ElasticSearch v6.8, to use OpenSearch v2.16.

This includes these changes:

- The need to authenticate for API access with basic authentication (username, password)
- It is no longer possible/necessary to specify a document type when indexing, as each index only supports one document type.
- We are switching to the `opensearch-py` client, owned by the same project/community that maintains OpenSearch itself.