### PR TITLE
fix: strip fenced code block language indicator from indexed text

### DIFF
--- a/hugo.py
+++ b/hugo.py
@@ -238,7 +238,10 @@ def get_pages(root_path):
 
 def markdown_to_text(markdown_text):
     """expects markdown unicode"""
-    html = markdown(markdown_text)
+    # The 'fenced_code' extension ensures triple-backtick code blocks are
+    # parsed properly, so a language indicator (e.g. ```nohighlight) ends up
+    # as a CSS class on the <code> element instead of leaking into the text.
+    html = markdown(markdown_text, extensions=["fenced_code"])
     text = html2text(html)
     text = text.replace(" | ", " ")
     text = re.sub(r"[\-]{3,}", "-", text)  # markdown tables

--- a/hugo_test.py
+++ b/hugo_test.py
@@ -1,5 +1,5 @@
 import unittest
-from hugo import get_front_matter
+from hugo import get_front_matter, markdown_to_text
 
 doc_with_yaml_front_matter = """---
 title: Node Pools
@@ -32,6 +32,15 @@ class TestFrontMatter(unittest.TestCase):
     def test_get_front_matter_none(self):
         data, text = get_front_matter(doc_without_front_matter, "nonepath")
         self.assertIs(data, None)
+
+
+class TestMarkdownToText(unittest.TestCase):
+
+    def test_fenced_code_language_indicator_stripped(self):
+        md = "Intro text.\n\n```nohighlight\nkubectl get pods\n```\n\nAfter text."
+        text = markdown_to_text(md)
+        self.assertNotIn("nohighlight", text)
+        self.assertIn("kubectl get pods", text)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What

The Hugo indexer converts fenced code blocks to plain text, but the language indicator was leaking into the indexed corpus. For example, a block opened with ` ```nohighlight ` caused the literal word `nohighlight` to be indexed as body text.

Search result illustrating the problem:

<img width="691" height="133" alt="image" src="https://github.com/user-attachments/assets/43ed36ba-19da-4bab-a991-58efa5da27b1" />


## Why

`markdown_to_text()` called `markdown()` without the `fenced_code` extension. Without it, python-markdown does not recognize triple-backtick fences and collapses ` ```nohighlight ` into inline `<code>`, so `html2text` extracts the language token as body text.

## How

Enable python-markdown's built-in `fenced_code` extension. Fenced blocks now render as `<pre><code class="language-nohighlight">…</code></pre>`, where the language becomes a CSS class (ignored by `html2text`) rather than text content. The code body itself is still indexed.

This applies to all language indicators (`bash`, `yaml`, `nohighlight`, …), stripping them consistently.

## Testing

- Added `test_fenced_code_language_indicator_stripped` to `hugo_test.py`.
- All tests pass (`python -m unittest hugo_test`).

Before: `'Intro text.\nnohighlight\nkubectl get pods\n…'`
After: `'Intro text.\nkubectl get pods\n…'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)