### PR TITLE
fix: parse markdown tables instead of leaking cell separators

### DIFF
--- a/hugo.py
+++ b/hugo.py
@@ -238,13 +238,14 @@ def get_pages(root_path):
 
 def markdown_to_text(markdown_text):
     """expects markdown unicode"""
-    # The 'fenced_code' extension ensures triple-backtick code blocks are
-    # parsed properly, so a language indicator (e.g. ```nohighlight) ends up
-    # as a CSS class on the <code> element instead of leaking into the text.
-    html = markdown(markdown_text, extensions=["fenced_code"])
+    # Extensions:
+    # - 'fenced_code' parses triple-backtick code blocks, so a language
+    #   indicator (e.g. ```nohighlight) ends up as a CSS class on the <code>
+    #   element instead of leaking into the text.
+    # - 'tables' parses Markdown tables into <table> markup, so the cell
+    #   separators (| and ---) don't leak into the indexed text.
+    html = markdown(markdown_text, extensions=["fenced_code", "tables"])
     text = html2text(html)
-    text = text.replace(" | ", " ")
-    text = re.sub(r"[\-]{3,}", "-", text)  # markdown tables
     return text
 
 

--- a/hugo_test.py
+++ b/hugo_test.py
@@ -42,6 +42,21 @@ class TestMarkdownToText(unittest.TestCase):
         self.assertNotIn("nohighlight", text)
         self.assertIn("kubectl get pods", text)
 
+    def test_table_separators_stripped(self):
+        md = (
+            "Intro.\n\n"
+            "| Name | Role |\n"
+            "| ---- | ---- |\n"
+            "| Alice | Admin |\n"
+            "| Bob | User |\n\n"
+            "Outro."
+        )
+        text = markdown_to_text(md)
+        self.assertNotIn("|", text)
+        self.assertNotIn("---", text)
+        for cell in ("Name", "Role", "Alice", "Admin", "Bob", "User"):
+            self.assertIn(cell, text)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## What

Enable parsing of Markdown tables in the Hugo indexer so that only the cell contents get indexed — the `|` and `---` separator characters no longer leak into the corpus.

## Why

`markdown_to_text()` did not enable python-markdown's `tables` extension, so a table like:

```
| Name | Role |
| ---- | ---- |
| Alice | Admin |
```

was passed through as a raw paragraph, leaving stray `|` and `---` in the indexed text. Two post-processing hacks (`text.replace(" | ", " ")` and a `[\-]{3,}` regex) tried to clean this up but only partially, and — now that fenced code blocks are preserved — those same hacks could corrupt `|` and `---` appearing legitimately inside code blocks.

## How

- Add the built-in `tables` extension alongside `fenced_code`. Tables now render as proper `<table>` markup, and `html2text` extracts just the cell text.
- Remove the two obsolete post-processing lines, which are no longer needed and were a correctness risk for code blocks.

## Testing

- Added `test_table_separators_stripped` to `hugo_test.py`.
- All tests pass (`python -m unittest hugo_test`).

Before: `'Intro.\n| Name Role |\n| - - |\n| Alice Admin |\n| Bob User |\nOutro.'`
After: `'Intro.\n\nName\nRole\n\nAlice\nAdmin\nBob\nUser\n\nOutro.'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)