### PR TITLE
fix: strip explicit heading anchors from indexed text

### DIFF
--- a/hugo.py
+++ b/hugo.py
@@ -244,7 +244,9 @@ def markdown_to_text(markdown_text):
     #   element instead of leaking into the text.
     # - 'tables' parses Markdown tables into <table> markup, so the cell
     #   separators (| and ---) don't leak into the indexed text.
-    html = markdown(markdown_text, extensions=["fenced_code", "tables"])
+    # - 'attr_list' parses explicit heading anchors (e.g. ## Title {#types})
+    #   into an id attribute, so the {#...} syntax doesn't leak into the text.
+    html = markdown(markdown_text, extensions=["fenced_code", "tables", "attr_list"])
     text = html2text(html)
     return text
 

--- a/hugo_test.py
+++ b/hugo_test.py
@@ -57,6 +57,14 @@ class TestMarkdownToText(unittest.TestCase):
         for cell in ("Name", "Role", "Alice", "Admin", "Bob", "User"):
             self.assertIn(cell, text)
 
+    def test_heading_anchor_stripped(self):
+        md = "## Resource types {#types}\n\nSome content.\n\n### Flags {#flags}\n\nMore."
+        text = markdown_to_text(md)
+        self.assertNotIn("{#types}", text)
+        self.assertNotIn("{#flags}", text)
+        self.assertIn("Resource types", text)
+        self.assertIn("Flags", text)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## What

Filter Hugo/Markdown explicit heading anchors out of the indexed text. A heading such as `## Resource types {#types}` was leaving the literal `{#types}` in the corpus (visible in search snippets); now only the heading text is indexed.

## Why

`markdown_to_text()` did not enable the `attr_list` extension, so the `{#...}` attribute syntax was treated as plain text and leaked into the index.

## How

Add python-markdown's built-in `attr_list` extension alongside `fenced_code` and `tables`. Explicit anchors are parsed into the element's `id` attribute (e.g. `<h2 id="types">Resource types</h2>`), which `html2text` drops.

## Testing

- Added `test_heading_anchor_stripped` to `hugo_test.py`.
- All tests pass (`python -m unittest hugo_test`).

Before: `'Resource types {#types}\nSome content.\nFlags {#flags}\nMore.'`
After: `'Resource types\nSome content.\nFlags\nMore.'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)