### PR TITLE
fix: strip Hugo shortcode tags from indexed text

### DIFF
--- a/hugo.py
+++ b/hugo.py
@@ -51,6 +51,11 @@ if GITHUB_TOKEN is not None:
 # published/last modified date
 DEFAULT_DATE = datetime(1900, 1, 1, 0, 0, 0)
 
+# Matches Hugo shortcode tags in both delimiter styles: {{< ... >}} and
+# {{% ... %}}, including opening, closing (with leading /) and parameterized
+# forms. Only the tag itself is matched, so any content it wraps is kept.
+SHORTCODE_RE = re.compile(r"\{\{[<%]/?.*?[%>]\}\}")
+
 def make_github_api_request(url, token=None, max_retries=3, base_delay=1.0):
     """
     Make a GitHub API request with retry logic and proper error handling.
@@ -238,6 +243,11 @@ def get_pages(root_path):
 
 def markdown_to_text(markdown_text):
     """expects markdown unicode"""
+    # Strip Hugo shortcode tags (e.g. {{< tabs >}}, {{% steps %}}) before
+    # conversion so they don't leak into the indexed text. Content wrapped
+    # by a shortcode is preserved and parsed as regular Markdown.
+    markdown_text = SHORTCODE_RE.sub("", markdown_text)
+
     # Extensions:
     # - 'fenced_code' parses triple-backtick code blocks, so a language
     #   indicator (e.g. ```nohighlight) ends up as a CSS class on the <code>

--- a/hugo_test.py
+++ b/hugo_test.py
@@ -65,6 +65,26 @@ class TestMarkdownToText(unittest.TestCase):
         self.assertIn("Resource types", text)
         self.assertIn("Flags", text)
 
+    def test_shortcodes_stripped(self):
+        md = (
+            "Install manually.\n\n"
+            "{{< tabs >}}\n"
+            "{{< tab name=\"Krew\" >}}\n"
+            "Pull the image.\n"
+            "{{< /tab >}}\n"
+            "{{< /tabs >}}\n\n"
+            "{{% steps %}}\n"
+            "Do the thing.\n"
+            "{{% /steps %}}\n"
+        )
+        text = markdown_to_text(md)
+        self.assertNotIn("{{", text)
+        self.assertNotIn("}}", text)
+        self.assertNotIn("tabs", text)
+        self.assertNotIn("steps", text)
+        self.assertIn("Pull the image.", text)
+        self.assertIn("Do the thing.", text)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## What

Filter Hugo shortcode tags out of the indexed text. Constructs like `{{< tabs >}}`, `{{< /tabs >}}`, and `{{% steps %}}` were leaking into the corpus (visible in search snippets); now only the content they wrap is indexed.

## Why

Shortcodes are a Hugo-specific templating construct, not Markdown, so no Markdown extension removes them. `markdown_to_text()` passed them through untouched, leaving the raw `{{< ... >}}` / `{{% ... %}}` tokens in the indexed text.

## How

Add a regex (`SHORTCODE_RE`) that matches shortcode tags in both delimiter styles — `{{< ... >}}` and `{{% ... %}}` — including opening, closing (leading `/`), and parameterized forms. It is applied before Markdown conversion. Only the tag itself is matched, so any content a shortcode wraps is preserved and parsed as regular Markdown.

## Testing

- Added `test_shortcodes_stripped` to `hugo_test.py`.
- All tests pass (`python -m unittest hugo_test`).

Before: `'Install manually.\n{{< tabs >}}\n{{< tab name="Krew" >}}\nPull the image.\n{{< /tab >}}\n{{< /tabs >}}\n{{% steps %}}\nDo the thing.\n{{% /steps %}}'`
After: `'Install manually.\n\nPull the image.\n\nDo the thing.'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)